### PR TITLE
Add dev server launch configuration for Claude Preview

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}


### PR DESCRIPTION
## Changes

- Add `.claude/launch.json` configuration file for Claude Preview
- Configure npm dev server launcher with:
  - Runtime executable: `npm`
  - Runtime arguments: `run dev`
  - Port: `5173`

This enables seamless development server launching from Claude Preview.