### PR TITLE
feat: save ideas and browse them on /ideas page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import ExplorePage from './pages/ExplorePage';
 import AssessPage from './pages/AssessPage';
 import ResultPage from './pages/ResultPage';
 import RefinePage from './pages/RefinePage';
+import IdeasPage from './pages/IdeasPage';
 
 export default function App() {
   return (
@@ -14,6 +15,7 @@ export default function App() {
         <Route path="/assess" element={<AssessPage />} />
         <Route path="/refine" element={<RefinePage />} />
         <Route path="/result" element={<ResultPage />} />
+        <Route path="/ideas" element={<IdeasPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/lib/ideas.ts
+++ b/src/lib/ideas.ts
@@ -1,0 +1,29 @@
+import { STORAGE_KEY_HISTORY } from './constants';
+import type { SavedIdea } from '../types';
+
+export function getSavedIdeas(): SavedIdea[] {
+  const stored = localStorage.getItem(STORAGE_KEY_HISTORY);
+  if (!stored) return [];
+  try {
+    return JSON.parse(stored) as SavedIdea[];
+  } catch {
+    return [];
+  }
+}
+
+export function saveIdea(idea: SavedIdea): void {
+  const ideas = getSavedIdeas();
+  // Replace if same id exists, otherwise prepend
+  const index = ideas.findIndex((i) => i.id === idea.id);
+  if (index >= 0) {
+    ideas[index] = idea;
+  } else {
+    ideas.unshift(idea);
+  }
+  localStorage.setItem(STORAGE_KEY_HISTORY, JSON.stringify(ideas));
+}
+
+export function deleteIdea(id: string): void {
+  const ideas = getSavedIdeas().filter((i) => i.id !== id);
+  localStorage.setItem(STORAGE_KEY_HISTORY, JSON.stringify(ideas));
+}

--- a/src/pages/IdeasPage.tsx
+++ b/src/pages/IdeasPage.tsx
@@ -1,0 +1,233 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Rocket,
+  Trash2,
+  Zap,
+  User,
+  Copy,
+  Check,
+  Lightbulb,
+} from 'lucide-react';
+import { getSavedIdeas, deleteIdea } from '../lib/ideas';
+import type { SavedIdea } from '../types';
+
+function verdictColor(score: number): string {
+  if (score >= 7.5) return 'text-green-500';
+  if (score >= 5.5) return 'text-orange-400';
+  return 'text-red-400';
+}
+
+function verdictLabel(score: number): string {
+  if (score >= 7.5) return 'Strong';
+  if (score >= 5.5) return 'Promising';
+  return 'Weak';
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'Just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export default function IdeasPage() {
+  const navigate = useNavigate();
+  const [ideas, setIdeas] = useState<SavedIdea[]>(getSavedIdeas);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  function handleDelete(id: string) {
+    deleteIdea(id);
+    setIdeas((prev) => prev.filter((i) => i.id !== id));
+  }
+
+  async function handleCopyPrompt(idea: SavedIdea) {
+    if (!idea.buildPrompt) return;
+    await navigator.clipboard.writeText(idea.buildPrompt);
+    setCopiedId(idea.id);
+    setTimeout(() => setCopiedId(null), 2000);
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <nav className="flex items-center gap-3 px-6 py-4 max-w-6xl mx-auto">
+        <button
+          onClick={() => navigate('/')}
+          className="rounded-lg p-2 hover:bg-gray-100 transition-colors cursor-pointer"
+        >
+          <ArrowLeft className="h-4 w-4 text-gray-500" />
+        </button>
+        <div className="flex items-center gap-2">
+          <div className="rounded-full bg-gradient-to-br from-orange-400 to-pink-400 p-1.5">
+            <Rocket className="h-3.5 w-3.5 text-white" />
+          </div>
+          <span className="font-bold">Launchable</span>
+        </div>
+      </nav>
+
+      <div className="w-[min(90%,1200px)] mx-auto pb-12">
+        <div className="text-center space-y-2 mb-8">
+          <h1 className="text-3xl font-bold">My Ideas</h1>
+          <p className="text-gray-500">
+            {ideas.length === 0
+              ? 'No saved ideas yet. Assess an idea and save it to see it here.'
+              : `${ideas.length} saved idea${ideas.length === 1 ? '' : 's'}`}
+          </p>
+        </div>
+
+        {ideas.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 gap-6">
+            <div className="rounded-full bg-gray-100 p-6">
+              <Lightbulb className="h-10 w-10 text-gray-300" />
+            </div>
+            <button
+              onClick={() => navigate('/assess')}
+              className="rounded-xl bg-gradient-to-r from-orange-400 to-pink-400 px-6 py-3 text-sm font-semibold text-white hover:from-orange-500 hover:to-pink-500 transition-all cursor-pointer shadow-sm"
+            >
+              Assess your first idea
+            </button>
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {ideas.map((idea) => (
+              <IdeaCard
+                key={idea.id}
+                idea={idea}
+                expanded={expandedId === idea.id}
+                copied={copiedId === idea.id}
+                onToggle={() => setExpandedId(expandedId === idea.id ? null : idea.id)}
+                onDelete={() => handleDelete(idea.id)}
+                onCopyPrompt={() => handleCopyPrompt(idea)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function IdeaCard({
+  idea,
+  expanded,
+  copied,
+  onToggle,
+  onDelete,
+  onCopyPrompt,
+}: {
+  idea: SavedIdea;
+  expanded: boolean;
+  copied: boolean;
+  onToggle: () => void;
+  onDelete: () => void;
+  onCopyPrompt: () => void;
+}) {
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white overflow-hidden transition-all hover:shadow-md">
+      {/* Header */}
+      <button onClick={onToggle} className="w-full text-left p-5 cursor-pointer">
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <p className="text-sm font-medium text-gray-900 leading-snug line-clamp-2">{idea.concept}</p>
+          <div className="shrink-0 text-right">
+            <span className={`text-xl font-black ${verdictColor(idea.score)}`}>{idea.score}</span>
+            <p className={`text-[10px] font-semibold ${verdictColor(idea.score)}`}>{verdictLabel(idea.score)}</p>
+          </div>
+        </div>
+
+        {/* Score bars */}
+        <div className="flex gap-3 text-[10px] text-gray-400 font-medium">
+          <div className="flex-1">
+            <div className="flex justify-between mb-0.5">
+              <span>Demand</span>
+              <span className="text-gray-600">{idea.demand}</span>
+            </div>
+            <div className="h-1 rounded-full bg-gray-100">
+              <div className="h-1 rounded-full bg-green-400" style={{ width: `${idea.demand * 10}%` }} />
+            </div>
+          </div>
+          <div className="flex-1">
+            <div className="flex justify-between mb-0.5">
+              <span>Competition</span>
+              <span className="text-gray-600">{idea.competition}</span>
+            </div>
+            <div className="h-1 rounded-full bg-gray-100">
+              <div className="h-1 rounded-full bg-amber-400" style={{ width: `${idea.competition * 10}%` }} />
+            </div>
+          </div>
+          <div className="flex-1">
+            <div className="flex justify-between mb-0.5">
+              <span>Ship</span>
+              <span className="text-gray-600">{idea.shippability}</span>
+            </div>
+            <div className="h-1 rounded-full bg-gray-100">
+              <div className="h-1 rounded-full bg-orange-400" style={{ width: `${idea.shippability * 10}%` }} />
+            </div>
+          </div>
+        </div>
+
+        {/* Meta */}
+        <div className="flex items-center gap-3 mt-3 text-[10px] text-gray-400">
+          {idea.persona ? (
+            <span className="flex items-center gap-1">
+              <User className="h-2.5 w-2.5" />
+              {idea.persona.name}
+            </span>
+          ) : null}
+          {idea.features ? (
+            <span>{idea.features.length} features</span>
+          ) : null}
+          <span className="ml-auto">{timeAgo(idea.savedAt)}</span>
+        </div>
+      </button>
+
+      {/* Expanded details */}
+      {expanded ? (
+        <div className="border-t border-gray-100 px-5 py-4 space-y-3">
+          <p className="text-xs text-gray-500 leading-relaxed">{idea.verdict}</p>
+
+          {idea.features && idea.features.length > 0 ? (
+            <div className="space-y-1">
+              <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Features</p>
+              <ul className="space-y-0.5">
+                {idea.features.map((f) => (
+                  <li key={f.id} className="text-xs text-gray-600 flex items-center gap-1.5">
+                    <Check className="h-2.5 w-2.5 text-green-500 shrink-0" />
+                    {f.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {/* Actions */}
+          <div className="flex gap-2 pt-1">
+            {idea.buildPrompt ? (
+              <button
+                onClick={onCopyPrompt}
+                className="flex-1 flex items-center justify-center gap-1.5 rounded-lg border border-gray-200 px-3 py-2 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+              >
+                {copied ? (
+                  <><Check className="h-3 w-3 text-green-500" /> Copied!</>
+                ) : (
+                  <><Copy className="h-3 w-3" /> Copy prompt</>
+                )}
+              </button>
+            ) : null}
+            <button
+              onClick={onDelete}
+              className="rounded-lg border border-red-200 px-3 py-2 text-xs font-medium text-red-400 hover:bg-red-50 hover:text-red-500 transition-colors cursor-pointer"
+            >
+              <Trash2 className="h-3 w-3" />
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,8 +1,10 @@
 import { useNavigate } from 'react-router-dom';
-import { Rocket } from 'lucide-react';
+import { Rocket, Bookmark } from 'lucide-react';
+import { getSavedIdeas } from '../lib/ideas';
 
 export default function LandingPage() {
   const navigate = useNavigate();
+  const savedCount = getSavedIdeas().length;
 
   return (
     <div className="min-h-screen bg-white text-gray-900">
@@ -15,6 +17,18 @@ export default function LandingPage() {
           <span className="font-bold text-lg">Launchable</span>
         </div>
         <div className="flex items-center gap-4">
+          {savedCount > 0 ? (
+            <button
+              onClick={() => navigate('/ideas')}
+              className="flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors cursor-pointer"
+            >
+              <Bookmark className="h-3.5 w-3.5" />
+              My Ideas
+              <span className="bg-gray-100 text-gray-500 text-xs font-bold rounded-full px-1.5 py-0.5 min-w-[1.25rem] text-center">
+                {savedCount}
+              </span>
+            </button>
+          ) : null}
           <button className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors cursor-pointer">
             Login
           </button>

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -10,11 +10,13 @@ import {
   Rocket,
   User,
   Star,
+  Bookmark,
 } from 'lucide-react';
 import { getAnthropicClient } from '../lib/claude';
 import { BUILD_PROMPT_SYSTEM } from '../lib/prompts';
 import { BUILD_TOOLS } from '../lib/constants';
-import type { Assessment, Persona, Feature, BuildPrompt } from '../types';
+import { saveIdea } from '../lib/ideas';
+import type { Assessment, Persona, Feature, BuildPrompt, SavedIdea } from '../types';
 
 interface RefinedResultState {
   concept: string;
@@ -45,6 +47,7 @@ export default function ResultPage() {
 
   const isRefined = state !== null && 'persona' in state;
   const [selectedTool, setSelectedTool] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
 
   useEffect(() => {
     if (!state || started.current) return;
@@ -126,6 +129,33 @@ export default function ResultPage() {
 
   const refined = state as RefinedResultState;
 
+  function handleSave() {
+    if (!buildPrompt) return;
+    const score = Math.round(
+      (refined.assessment.demand.score * 0.4 +
+        (10 - refined.assessment.competition.score) * 0.25 +
+        refined.assessment.shippability.score * 0.35) * 10,
+    ) / 10;
+
+    const idea: SavedIdea = {
+      id: `idea-${Date.now()}`,
+      concept: refined.concept,
+      audience: refined.audience,
+      score,
+      verdict: refined.assessment.verdict,
+      demand: refined.assessment.demand.score,
+      competition: refined.assessment.competition.score,
+      shippability: refined.assessment.shippability.score,
+      persona: refined.persona,
+      features: refined.features,
+      buildPrompt: buildPrompt.prompt,
+      buildTool: buildPrompt.tool,
+      savedAt: new Date().toISOString(),
+    };
+    saveIdea(idea);
+    setSaved(true);
+  }
+
   return (
     <div className="min-h-screen bg-white">
       <nav className="flex items-center gap-3 px-6 py-4 max-w-6xl mx-auto">
@@ -141,6 +171,20 @@ export default function ResultPage() {
           </div>
           <span className="font-bold">Launchable</span>
         </div>
+        {buildPrompt ? (
+          <button
+            onClick={handleSave}
+            disabled={saved}
+            className={`ml-auto flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all cursor-pointer ${
+              saved
+                ? 'bg-green-50 text-green-600 border border-green-200'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200 border border-gray-200'
+            }`}
+          >
+            {saved ? <Check className="h-3.5 w-3.5" /> : <Bookmark className="h-3.5 w-3.5" />}
+            {saved ? 'Saved!' : 'Save idea'}
+          </button>
+        ) : null}
       </nav>
 
       <div className="w-[min(90%,1200px)] mx-auto pb-12 space-y-6">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,6 +87,22 @@ export interface BuildPrompt {
   reasoning: string;
 }
 
+export interface SavedIdea {
+  id: string;
+  concept: string;
+  audience?: string;
+  score: number;
+  verdict: string;
+  demand: number;
+  competition: number;
+  shippability: number;
+  persona?: Persona;
+  features?: Feature[];
+  buildPrompt?: string;
+  buildTool?: string;
+  savedAt: string;
+}
+
 export interface ExploreMessage {
   role: 'assistant' | 'user';
   content: string;


### PR DESCRIPTION
## Summary
- **Save button** in ResultPage nav — saves idea snapshot (scores, persona, features, build prompt) to localStorage
- **`/ideas` page** — grid of expandable cards showing each saved idea with score, dimension bars, persona, features list, copy prompt, and delete
- **Landing page** — "My Ideas" link with count badge appears when saved ideas exist

## Changes
- `src/types/index.ts` — Added `SavedIdea` interface
- `src/lib/ideas.ts` — New: `getSavedIdeas`, `saveIdea`, `deleteIdea` (localStorage)
- `src/pages/ResultPage.tsx` — Save button in nav, `handleSave` function
- `src/pages/IdeasPage.tsx` — New page with expandable idea cards
- `src/pages/LandingPage.tsx` — "My Ideas" nav link with count
- `src/App.tsx` — Added `/ideas` route

## Test plan
- [ ] Complete full flow (assess → refine → result), click "Save idea"
- [ ] Button changes to "Saved!" with checkmark
- [ ] Navigate to landing page, verify "My Ideas" link with count badge
- [ ] Click through to /ideas, verify card shows score, bars, persona, time ago
- [ ] Expand card, verify features list and verdict
- [ ] Copy prompt button works
- [ ] Delete button removes card
- [ ] Refresh page, verify ideas persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)