### PR TITLE
feat: fake login with avatar and user menu

### DIFF
--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Rocket } from 'lucide-react';
+import { ArrowLeft, Rocket, LogOut } from 'lucide-react';
+import { getUser, login, logout, type User } from '../lib/auth';
 
 interface PageLayoutProps {
   children: ReactNode;
@@ -17,6 +18,10 @@ const WIDTH_CLASS = {
 
 export default function PageLayout({ children, back, actions, width = 'wide' }: PageLayoutProps) {
   const navigate = useNavigate();
+  const [user, setUser] = useState<User | null>(getUser);
+  const [showLogin, setShowLogin] = useState(false);
+  const [showMenu, setShowMenu] = useState(false);
+  const [nameInput, setNameInput] = useState('');
 
   function handleBack() {
     if (back === 'history') {
@@ -24,6 +29,21 @@ export default function PageLayout({ children, back, actions, width = 'wide' }: 
     } else if (back) {
       navigate(back);
     }
+  }
+
+  function handleLogin(e: React.FormEvent) {
+    e.preventDefault();
+    if (!nameInput.trim()) return;
+    const u = login(nameInput);
+    setUser(u);
+    setShowLogin(false);
+    setNameInput('');
+  }
+
+  function handleLogout() {
+    logout();
+    setUser(null);
+    setShowMenu(false);
   }
 
   return (
@@ -46,16 +66,86 @@ export default function PageLayout({ children, back, actions, width = 'wide' }: 
           </div>
           <span className="font-bold">Launchable</span>
         </button>
-        {actions ? (
-          <div className="ml-auto flex items-center gap-4">
-            {actions}
-          </div>
-        ) : null}
+
+        <div className="ml-auto flex items-center gap-4">
+          {actions}
+
+          {/* Auth */}
+          {user ? (
+            <div className="relative">
+              <button
+                onClick={() => setShowMenu(!showMenu)}
+                className="flex items-center gap-2 cursor-pointer rounded-lg px-2 py-1 hover:bg-gray-100 transition-colors"
+              >
+                <div className="w-7 h-7 rounded-full bg-gradient-to-br from-orange-400 to-pink-400 flex items-center justify-center">
+                  <span className="text-[10px] font-bold text-white">{user.initials}</span>
+                </div>
+                <span className="text-sm font-medium text-gray-700 hidden sm:block">{user.name}</span>
+              </button>
+
+              {showMenu ? (
+                <>
+                  <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)} />
+                  <div className="absolute right-0 top-full mt-1 z-50 w-48 rounded-xl border border-gray-200 bg-white shadow-lg p-1">
+                    <button
+                      onClick={handleLogout}
+                      className="w-full flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer transition-colors"
+                    >
+                      <LogOut className="h-3.5 w-3.5" />
+                      Log out
+                    </button>
+                  </div>
+                </>
+              ) : null}
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowLogin(true)}
+              className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors cursor-pointer"
+            >
+              Login
+            </button>
+          )}
+        </div>
       </nav>
 
       <div className={`${WIDTH_CLASS[width]} pb-12`}>
         {children}
       </div>
+
+      {/* Login modal */}
+      {showLogin ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={() => setShowLogin(false)} />
+          <div className="relative rounded-2xl bg-white border border-gray-200 p-8 max-w-sm w-full shadow-xl space-y-6">
+            <div className="text-center space-y-2">
+              <div className="mx-auto w-12 h-12 rounded-full bg-gradient-to-br from-orange-100 to-pink-100 flex items-center justify-center">
+                <Rocket className="h-6 w-6 text-orange-500" />
+              </div>
+              <h2 className="text-xl font-bold text-gray-900">Welcome to Launchable</h2>
+              <p className="text-sm text-gray-500">Enter your name to get started.</p>
+            </div>
+
+            <form onSubmit={handleLogin} className="space-y-3">
+              <input
+                type="text"
+                value={nameInput}
+                onChange={(e) => setNameInput(e.target.value)}
+                placeholder="Your name"
+                autoFocus
+                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:border-orange-300 focus:ring-2 focus:ring-orange-100"
+              />
+              <button
+                type="submit"
+                disabled={!nameInput.trim()}
+                className="w-full rounded-xl bg-gradient-to-r from-orange-400 to-pink-400 px-4 py-3 text-sm font-semibold text-white hover:from-orange-500 hover:to-pink-500 transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-sm"
+              >
+                Continue
+              </button>
+            </form>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,34 @@
+const STORAGE_KEY = 'launchable_user';
+
+export interface User {
+  name: string;
+  initials: string;
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+export function getUser(): User | null {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (!stored) return null;
+  try {
+    return JSON.parse(stored) as User;
+  } catch {
+    return null;
+  }
+}
+
+export function login(name: string): User {
+  const user: User = { name: name.trim(), initials: getInitials(name.trim()) };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(user));
+  return user;
+}
+
+export function logout(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -24,9 +24,6 @@ export default function LandingPage() {
               </span>
             </button>
           ) : null}
-          <button className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors cursor-pointer">
-            Login
-          </button>
           <button
             onClick={() => navigate('/assess')}
             className="text-sm font-medium bg-gray-900 text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors cursor-pointer"


### PR DESCRIPTION
## Summary
- Fake auth system using localStorage — enter a name, get an avatar with initials
- Login modal triggered from nav bar (on all pages via PageLayout)
- Logged-in state shows avatar + name with dropdown menu to log out
- No real auth backend — ready to swap in when needed

## Changes
- `src/lib/auth.ts` — `getUser`, `login`, `logout` with `User` type (name + initials)
- `src/components/PageLayout.tsx` — Login/avatar in nav, login modal, dropdown menu
- `src/pages/LandingPage.tsx` — Removed duplicate Login button

## Test plan
- [ ] Click "Login" in nav → modal appears
- [ ] Enter name → avatar with initials appears in nav
- [ ] Refresh page → still logged in
- [ ] Click avatar → dropdown with "Log out"
- [ ] Log out → Login button returns
- [ ] Works on all pages (landing, assess, refine, result, ideas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)