### PR TITLE
feat: sidebar nav for logged-in users with starred ideas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ export default function App() {
         <Route path="/refine" element={<RefinePage />} />
         <Route path="/result" element={<ResultPage />} />
         <Route path="/ideas" element={<IdeasPage />} />
+        <Route path="/ideas/starred" element={<IdeasPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,7 +1,17 @@
 import { type ReactNode, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Rocket, LogOut } from 'lucide-react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Rocket,
+  LogOut,
+  Home,
+  Search,
+  BookOpen,
+  Lightbulb,
+  Star,
+} from 'lucide-react';
 import { getUser, login, logout, type User } from '../lib/auth';
+import { getSavedIdeas } from '../lib/ideas';
 
 interface PageLayoutProps {
   children: ReactNode;
@@ -18,9 +28,9 @@ const WIDTH_CLASS = {
 
 export default function PageLayout({ children, back, actions, width = 'wide' }: PageLayoutProps) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [user, setUser] = useState<User | null>(getUser);
   const [showLogin, setShowLogin] = useState(false);
-  const [showMenu, setShowMenu] = useState(false);
   const [nameInput, setNameInput] = useState('');
 
   function handleBack() {
@@ -43,109 +53,248 @@ export default function PageLayout({ children, back, actions, width = 'wide' }: 
   function handleLogout() {
     logout();
     setUser(null);
-    setShowMenu(false);
   }
 
-  return (
-    <div className="min-h-screen bg-white">
-      <nav className="flex items-center gap-3 px-6 py-4 max-w-6xl mx-auto">
-        {back ? (
+  // ---- Logged out: top nav ----
+  if (!user) {
+    return (
+      <div className="min-h-screen bg-white">
+        <nav className="flex items-center gap-3 px-6 py-4 max-w-6xl mx-auto">
+          {back ? (
+            <button
+              onClick={handleBack}
+              className="rounded-lg p-2 hover:bg-gray-100 transition-colors cursor-pointer"
+            >
+              <ArrowLeft className="h-4 w-4 text-gray-500" />
+            </button>
+          ) : null}
           <button
-            onClick={handleBack}
-            className="rounded-lg p-2 hover:bg-gray-100 transition-colors cursor-pointer"
+            onClick={() => navigate('/')}
+            className="flex items-center gap-2 cursor-pointer"
           >
-            <ArrowLeft className="h-4 w-4 text-gray-500" />
-          </button>
-        ) : null}
-        <button
-          onClick={() => navigate('/')}
-          className="flex items-center gap-2 cursor-pointer"
-        >
-          <div className="rounded-full bg-gradient-to-br from-orange-400 to-pink-400 p-1.5">
-            <Rocket className="h-3.5 w-3.5 text-white" />
-          </div>
-          <span className="font-bold">Launchable</span>
-        </button>
-
-        <div className="ml-auto flex items-center gap-4">
-          {actions}
-
-          {/* Auth */}
-          {user ? (
-            <div className="relative">
-              <button
-                onClick={() => setShowMenu(!showMenu)}
-                className="flex items-center gap-2 cursor-pointer rounded-lg px-2 py-1 hover:bg-gray-100 transition-colors"
-              >
-                <div className="w-7 h-7 rounded-full bg-gradient-to-br from-orange-400 to-pink-400 flex items-center justify-center">
-                  <span className="text-[10px] font-bold text-white">{user.initials}</span>
-                </div>
-                <span className="text-sm font-medium text-gray-700 hidden sm:block">{user.name}</span>
-              </button>
-
-              {showMenu ? (
-                <>
-                  <div className="fixed inset-0 z-40" onClick={() => setShowMenu(false)} />
-                  <div className="absolute right-0 top-full mt-1 z-50 w-48 rounded-xl border border-gray-200 bg-white shadow-lg p-1">
-                    <button
-                      onClick={handleLogout}
-                      className="w-full flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 cursor-pointer transition-colors"
-                    >
-                      <LogOut className="h-3.5 w-3.5" />
-                      Log out
-                    </button>
-                  </div>
-                </>
-              ) : null}
+            <div className="rounded-full bg-gradient-to-br from-orange-400 to-pink-400 p-1.5">
+              <Rocket className="h-3.5 w-3.5 text-white" />
             </div>
-          ) : (
+            <span className="font-bold">Launchable</span>
+          </button>
+          <div className="ml-auto flex items-center gap-4">
+            {actions}
             <button
               onClick={() => setShowLogin(true)}
               className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors cursor-pointer"
             >
               Login
             </button>
-          )}
+          </div>
+        </nav>
+
+        <div className={`${WIDTH_CLASS[width]} pb-12`}>
+          {children}
         </div>
-      </nav>
 
-      <div className={`${WIDTH_CLASS[width]} pb-12`}>
-        {children}
+        <LoginModal
+          open={showLogin}
+          onClose={() => setShowLogin(false)}
+          nameInput={nameInput}
+          setNameInput={setNameInput}
+          onSubmit={handleLogin}
+        />
       </div>
+    );
+  }
 
-      {/* Login modal */}
-      {showLogin ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-          <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={() => setShowLogin(false)} />
-          <div className="relative rounded-2xl bg-white border border-gray-200 p-8 max-w-sm w-full shadow-xl space-y-6">
-            <div className="text-center space-y-2">
-              <div className="mx-auto w-12 h-12 rounded-full bg-gradient-to-br from-orange-100 to-pink-100 flex items-center justify-center">
-                <Rocket className="h-6 w-6 text-orange-500" />
-              </div>
-              <h2 className="text-xl font-bold text-gray-900">Welcome to Launchable</h2>
-              <p className="text-sm text-gray-500">Enter your name to get started.</p>
+  // ---- Logged in: sidebar ----
+  const ideas = getSavedIdeas();
+  const starredCount = ideas.filter((i) => i.starred).length;
+
+  return (
+    <div className="min-h-screen bg-white flex">
+      {/* Sidebar */}
+      <aside className="w-56 shrink-0 border-r border-gray-100 flex flex-col h-screen sticky top-0">
+        {/* Logo */}
+        <div className="px-5 py-5">
+          <button
+            onClick={() => navigate('/')}
+            className="flex items-center gap-2 cursor-pointer"
+          >
+            <div className="rounded-full bg-gradient-to-br from-orange-400 to-pink-400 p-1.5">
+              <Rocket className="h-3.5 w-3.5 text-white" />
             </div>
+            <span className="font-bold">Launchable</span>
+          </button>
+        </div>
 
-            <form onSubmit={handleLogin} className="space-y-3">
-              <input
-                type="text"
-                value={nameInput}
-                onChange={(e) => setNameInput(e.target.value)}
-                placeholder="Your name"
-                autoFocus
-                className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:border-orange-300 focus:ring-2 focus:ring-orange-100"
-              />
-              <button
-                type="submit"
-                disabled={!nameInput.trim()}
-                className="w-full rounded-xl bg-gradient-to-r from-orange-400 to-pink-400 px-4 py-3 text-sm font-semibold text-white hover:from-orange-500 hover:to-pink-500 transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-sm"
-              >
-                Continue
-              </button>
-            </form>
+        {/* Main nav */}
+        <nav className="px-3 space-y-0.5">
+          <SidebarLink icon={Home} label="Home" path="/" current={location.pathname} onClick={() => navigate('/')} />
+          <SidebarLink icon={Search} label="Search" path="/explore" current={location.pathname} onClick={() => navigate('/explore')} />
+          <SidebarLink icon={BookOpen} label="Resources" path="/resources" current={location.pathname} onClick={() => navigate('/resources')} />
+        </nav>
+
+        {/* Ideas section */}
+        <div className="mt-6 px-3">
+          <p className="px-3 mb-1 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Ideas</p>
+          <nav className="space-y-0.5">
+            <SidebarLink
+              icon={Lightbulb}
+              label="All Ideas"
+              path="/ideas"
+              current={location.pathname}
+              onClick={() => navigate('/ideas')}
+              badge={ideas.length > 0 ? ideas.length : undefined}
+            />
+            <SidebarLink
+              icon={Star}
+              label="Starred"
+              path="/ideas/starred"
+              current={location.pathname}
+              onClick={() => navigate('/ideas/starred')}
+              badge={starredCount > 0 ? starredCount : undefined}
+            />
+          </nav>
+        </div>
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* User footer */}
+        <div className="border-t border-gray-100 px-3 py-3">
+          <div className="flex items-center gap-2.5 px-3 py-2 rounded-lg">
+            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-orange-400 to-pink-400 flex items-center justify-center shrink-0">
+              <span className="text-[11px] font-bold text-white">{user.initials}</span>
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-gray-900 truncate">{user.name}</p>
+              <p className="text-[10px] text-gray-400">Free plan</p>
+            </div>
+            <button
+              onClick={handleLogout}
+              className="shrink-0 rounded-md p-1 hover:bg-gray-100 transition-colors cursor-pointer"
+              title="Log out"
+            >
+              <LogOut className="h-3.5 w-3.5 text-gray-400" />
+            </button>
           </div>
         </div>
+      </aside>
+
+      {/* Main content */}
+      <main className="flex-1 min-w-0">
+        {/* Contextual top bar (back button + actions) */}
+        {back || actions ? (
+          <div className="flex items-center gap-3 px-6 py-4">
+            {back ? (
+              <button
+                onClick={handleBack}
+                className="rounded-lg p-2 hover:bg-gray-100 transition-colors cursor-pointer"
+              >
+                <ArrowLeft className="h-4 w-4 text-gray-500" />
+              </button>
+            ) : null}
+            {actions ? (
+              <div className="ml-auto flex items-center gap-4">
+                {actions}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        <div className={`${WIDTH_CLASS[width]} pb-12`}>
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+// ---- Sidebar link ----
+
+function SidebarLink({
+  icon: Icon,
+  label,
+  path,
+  current,
+  onClick,
+  badge,
+}: {
+  icon: typeof Home;
+  label: string;
+  path: string;
+  current: string;
+  onClick: () => void;
+  badge?: number;
+}) {
+  const isActive = current === path;
+
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition-colors cursor-pointer ${
+        isActive
+          ? 'bg-orange-50 text-orange-600 font-medium'
+          : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+      }`}
+    >
+      <Icon className={`h-4 w-4 shrink-0 ${isActive ? 'text-orange-500' : 'text-gray-400'}`} />
+      <span className="flex-1 text-left">{label}</span>
+      {badge !== undefined ? (
+        <span className={`text-[10px] font-bold rounded-full px-1.5 py-0.5 min-w-[1.25rem] text-center ${
+          isActive ? 'bg-orange-100 text-orange-500' : 'bg-gray-100 text-gray-400'
+        }`}>
+          {badge}
+        </span>
       ) : null}
+    </button>
+  );
+}
+
+// ---- Login modal ----
+
+function LoginModal({
+  open,
+  onClose,
+  nameInput,
+  setNameInput,
+  onSubmit,
+}: {
+  open: boolean;
+  onClose: () => void;
+  nameInput: string;
+  setNameInput: (v: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative rounded-2xl bg-white border border-gray-200 p-8 max-w-sm w-full shadow-xl space-y-6">
+        <div className="text-center space-y-2">
+          <div className="mx-auto w-12 h-12 rounded-full bg-gradient-to-br from-orange-100 to-pink-100 flex items-center justify-center">
+            <Rocket className="h-6 w-6 text-orange-500" />
+          </div>
+          <h2 className="text-xl font-bold text-gray-900">Welcome to Launchable</h2>
+          <p className="text-sm text-gray-500">Enter your name to get started.</p>
+        </div>
+
+        <form onSubmit={onSubmit} className="space-y-3">
+          <input
+            type="text"
+            value={nameInput}
+            onChange={(e) => setNameInput(e.target.value)}
+            placeholder="Your name"
+            autoFocus
+            className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:border-orange-300 focus:ring-2 focus:ring-orange-100"
+          />
+          <button
+            type="submit"
+            disabled={!nameInput.trim()}
+            className="w-full rounded-xl bg-gradient-to-r from-orange-400 to-pink-400 px-4 py-3 text-sm font-semibold text-white hover:from-orange-500 hover:to-pink-500 transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer shadow-sm"
+          >
+            Continue
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/src/lib/ideas.ts
+++ b/src/lib/ideas.ts
@@ -27,3 +27,10 @@ export function deleteIdea(id: string): void {
   const ideas = getSavedIdeas().filter((i) => i.id !== id);
   localStorage.setItem(STORAGE_KEY_HISTORY, JSON.stringify(ideas));
 }
+
+export function toggleStar(id: string): void {
+  const ideas = getSavedIdeas().map((i) =>
+    i.id === id ? { ...i, starred: !i.starred } : i,
+  );
+  localStorage.setItem(STORAGE_KEY_HISTORY, JSON.stringify(ideas));
+}

--- a/src/pages/IdeasPage.tsx
+++ b/src/pages/IdeasPage.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Trash2,
   User,
   Copy,
   Check,
   Lightbulb,
+  Star,
 } from 'lucide-react';
-import { getSavedIdeas, deleteIdea } from '../lib/ideas';
+import { getSavedIdeas, deleteIdea, toggleStar } from '../lib/ideas';
 import PageLayout from '../components/PageLayout';
 import type { SavedIdea } from '../types';
 
@@ -36,13 +37,24 @@ function timeAgo(iso: string): string {
 
 export default function IdeasPage() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const isStarredView = location.pathname === '/ideas/starred';
   const [ideas, setIdeas] = useState<SavedIdea[]>(getSavedIdeas);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
+  const filtered = isStarredView ? ideas.filter((i) => i.starred) : ideas;
+
   function handleDelete(id: string) {
     deleteIdea(id);
     setIdeas((prev) => prev.filter((i) => i.id !== id));
+  }
+
+  function handleToggleStar(id: string) {
+    toggleStar(id);
+    setIdeas((prev) =>
+      prev.map((i) => (i.id === id ? { ...i, starred: !i.starred } : i)),
+    );
   }
 
   async function handleCopyPrompt(idea: SavedIdea) {
@@ -52,44 +64,56 @@ export default function IdeasPage() {
     setTimeout(() => setCopiedId(null), 2000);
   }
 
-  return (
-    <PageLayout back="/" width="wide">
-      <div className="text-center space-y-2 mb-8">
-          <h1 className="text-3xl font-bold">My Ideas</h1>
-          <p className="text-gray-500">
-            {ideas.length === 0
-              ? 'No saved ideas yet. Assess an idea and save it to see it here.'
-              : `${ideas.length} saved idea${ideas.length === 1 ? '' : 's'}`}
-          </p>
-        </div>
+  const title = isStarredView ? 'Starred Ideas' : 'All Ideas';
+  const emptyMessage = isStarredView
+    ? 'No starred ideas yet. Star an idea to see it here.'
+    : 'No saved ideas yet. Assess an idea and save it to see it here.';
 
-        {ideas.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 gap-6">
-            <div className="rounded-full bg-gray-100 p-6">
+  return (
+    <PageLayout width="wide">
+      <div className="text-center space-y-2 mb-8">
+        <h1 className="text-3xl font-bold">{title}</h1>
+        <p className="text-gray-500">
+          {filtered.length === 0
+            ? emptyMessage
+            : `${filtered.length} idea${filtered.length === 1 ? '' : 's'}`}
+        </p>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-20 gap-6">
+          <div className="rounded-full bg-gray-100 p-6">
+            {isStarredView ? (
+              <Star className="h-10 w-10 text-gray-300" />
+            ) : (
               <Lightbulb className="h-10 w-10 text-gray-300" />
-            </div>
+            )}
+          </div>
+          {isStarredView ? null : (
             <button
               onClick={() => navigate('/assess')}
               className="rounded-xl bg-gradient-to-r from-orange-400 to-pink-400 px-6 py-3 text-sm font-semibold text-white hover:from-orange-500 hover:to-pink-500 transition-all cursor-pointer shadow-sm"
             >
               Assess your first idea
             </button>
-          </div>
-        ) : (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {ideas.map((idea) => (
-              <IdeaCard
-                key={idea.id}
-                idea={idea}
-                expanded={expandedId === idea.id}
-                copied={copiedId === idea.id}
-                onToggle={() => setExpandedId(expandedId === idea.id ? null : idea.id)}
-                onDelete={() => handleDelete(idea.id)}
-                onCopyPrompt={() => handleCopyPrompt(idea)}
-              />
-            ))}
-          </div>
-        )}
+          )}
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((idea) => (
+            <IdeaCard
+              key={idea.id}
+              idea={idea}
+              expanded={expandedId === idea.id}
+              copied={copiedId === idea.id}
+              onToggle={() => setExpandedId(expandedId === idea.id ? null : idea.id)}
+              onDelete={() => handleDelete(idea.id)}
+              onToggleStar={() => handleToggleStar(idea.id)}
+              onCopyPrompt={() => handleCopyPrompt(idea)}
+            />
+          ))}
+        </div>
+      )}
     </PageLayout>
   );
 }
@@ -100,6 +124,7 @@ function IdeaCard({
   copied,
   onToggle,
   onDelete,
+  onToggleStar,
   onCopyPrompt,
 }: {
   idea: SavedIdea;
@@ -107,6 +132,7 @@ function IdeaCard({
   copied: boolean;
   onToggle: () => void;
   onDelete: () => void;
+  onToggleStar: () => void;
   onCopyPrompt: () => void;
 }) {
   return (
@@ -188,6 +214,17 @@ function IdeaCard({
 
           {/* Actions */}
           <div className="flex gap-2 pt-1">
+            <button
+              onClick={onToggleStar}
+              className={`rounded-lg border px-3 py-2 text-xs font-medium transition-colors cursor-pointer flex items-center gap-1.5 ${
+                idea.starred
+                  ? 'border-orange-200 bg-orange-50 text-orange-500'
+                  : 'border-gray-200 text-gray-400 hover:bg-gray-50'
+              }`}
+            >
+              <Star className={`h-3 w-3 ${idea.starred ? 'fill-orange-400' : ''}`} />
+              {idea.starred ? 'Starred' : 'Star'}
+            </button>
             {idea.buildPrompt ? (
               <button
                 onClick={onCopyPrompt}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,36 +1,19 @@
 import { useNavigate } from 'react-router-dom';
-import { Bookmark } from 'lucide-react';
-import { getSavedIdeas } from '../lib/ideas';
 import PageLayout from '../components/PageLayout';
 
 export default function LandingPage() {
   const navigate = useNavigate();
-  const savedCount = getSavedIdeas().length;
 
   return (
     <PageLayout
       width="medium"
       actions={
-        <>
-          {savedCount > 0 ? (
-            <button
-              onClick={() => navigate('/ideas')}
-              className="flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors cursor-pointer"
-            >
-              <Bookmark className="h-3.5 w-3.5" />
-              My Ideas
-              <span className="bg-gray-100 text-gray-500 text-xs font-bold rounded-full px-1.5 py-0.5 min-w-[1.25rem] text-center">
-                {savedCount}
-              </span>
-            </button>
-          ) : null}
-          <button
-            onClick={() => navigate('/assess')}
-            className="text-sm font-medium bg-gray-900 text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors cursor-pointer"
-          >
-            Get Started
-          </button>
-        </>
+        <button
+          onClick={() => navigate('/assess')}
+          className="text-sm font-medium bg-gray-900 text-white px-4 py-2 rounded-lg hover:bg-gray-800 transition-colors cursor-pointer"
+        >
+          Get Started
+        </button>
       }
     >
       {/* Hero */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,6 +100,7 @@ export interface SavedIdea {
   features?: Feature[];
   buildPrompt?: string;
   buildTool?: string;
+  starred?: boolean;
   savedAt: string;
 }
 


### PR DESCRIPTION
## Summary
Two layout modes based on auth state:

**Logged out** — top nav with logo, Login button, page actions. No saved plans visible.

**Logged in** — persistent sidebar:
- Logo at top
- Home, Search, Resources nav links
- Ideas section: "All Ideas" (with count badge), "Starred" (with count badge)
- Avatar + name + "Free plan" + logout at bottom

Also adds star/unstar functionality to saved ideas.

## Changes
- `src/components/PageLayout.tsx` — Dual layout (top nav vs sidebar), active state highlighting
- `src/pages/IdeasPage.tsx` — Star toggle button, `/ideas/starred` filter view
- `src/pages/LandingPage.tsx` — Removed "My Ideas" link (sidebar handles it)
- `src/lib/ideas.ts` — Added `toggleStar`
- `src/types/index.ts` — Added `starred` to `SavedIdea`
- `src/App.tsx` — Added `/ideas/starred` route

## Test plan
- [ ] Logged out: top nav, no sidebar, no saved plans visible
- [ ] Click Login → enter name → sidebar appears
- [ ] Sidebar links highlight based on current route
- [ ] All Ideas shows count badge, Starred shows starred count
- [ ] Expand an idea card → Star button toggles
- [ ] Navigate to /ideas/starred → only starred ideas shown
- [ ] Avatar + name at bottom, logout works
- [ ] Refresh → sidebar persists (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)