### PR TITLE
feat(convex): add checkLimit query and regenerate API types

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,8 @@
 
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
+import type * as ideas from "../ideas.js";
+import type * as usage from "../usage.js";
 import type * as users from "../users.js";
 
 import type {
@@ -21,6 +23,8 @@ import type {
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   http: typeof http;
+  ideas: typeof ideas;
+  usage: typeof usage;
   users: typeof users;
 }>;
 

--- a/convex/usage.ts
+++ b/convex/usage.ts
@@ -1,6 +1,8 @@
 import { query, mutation } from "./_generated/server";
 import { getAuthUserId } from "@convex-dev/auth/server";
 
+const FREE_ASSESSMENT_LIMIT = 3;
+
 export const get = query({
   args: {},
   handler: async (ctx) => {
@@ -33,5 +35,23 @@ export const increment = mutation({
       periodStart: Date.now(),
     });
     return 1;
+  },
+});
+
+export const checkLimit = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) return { allowed: false, count: 0, limit: FREE_ASSESSMENT_LIMIT };
+    const usage = await ctx.db
+      .query("usage")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .first();
+    const count = usage?.count ?? 0;
+    return {
+      allowed: count < FREE_ASSESSMENT_LIMIT,
+      count,
+      limit: FREE_ASSESSMENT_LIMIT,
+    };
   },
 });


### PR DESCRIPTION
## Summary
- Add `checkLimit` query to `convex/usage.ts` for server-side free tier enforcement (3 assessments)
- Regenerate `convex/_generated/api.d.ts` so the build recognizes `api.ideas.*` and `api.usage.*`

## Test plan
- [x] `npm run build` passes with zero TS errors
- [x] `npx convex dev --once` deploys successfully
- [ ] Usage limit query returns correct `{ allowed, count, limit }`

Closes #23, Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)