### PR TITLE
feat(convex): add server-side AI actions and wire frontend

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -8,9 +8,11 @@
  * @module
  */
 
+import type * as ai from "../ai.js";
 import type * as auth from "../auth.js";
 import type * as http from "../http.js";
 import type * as ideas from "../ideas.js";
+import type * as prompts from "../prompts.js";
 import type * as usage from "../usage.js";
 import type * as users from "../users.js";
 
@@ -21,9 +23,11 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  ai: typeof ai;
   auth: typeof auth;
   http: typeof http;
   ideas: typeof ideas;
+  prompts: typeof prompts;
   usage: typeof usage;
   users: typeof users;
 }>;

--- a/convex/ai.ts
+++ b/convex/ai.ts
@@ -1,0 +1,230 @@
+"use node";
+
+import Anthropic from "@anthropic-ai/sdk";
+import Groq from "groq-sdk";
+import { action } from "./_generated/server";
+import { v } from "convex/values";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { api } from "./_generated/api";
+import {
+  ASSESS_SYSTEM_PROMPT,
+  REFINE_SYSTEM_PROMPT,
+  BUILD_PROMPT_SYSTEM,
+  CONCEPT_PROMPT,
+} from "./prompts";
+
+function getAnthropicClient(): Anthropic {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("Missing ANTHROPIC_API_KEY environment variable");
+  return new Anthropic({ apiKey });
+}
+
+function getGroqClient(): Groq {
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) throw new Error("Missing GROQ_API_KEY environment variable");
+  return new Groq({ apiKey });
+}
+
+function extractJSON(text: string): string {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) throw new Error("No valid JSON found in AI response");
+  // Validate it parses
+  JSON.parse(match[0]);
+  return match[0];
+}
+
+// ---------- assess ----------
+
+export const assess = action({
+  args: {
+    concept: v.string(),
+    audience: v.optional(v.string()),
+    timeline: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    // Check usage limit server-side
+    const { allowed } = await ctx.runQuery(api.usage.checkLimit);
+    if (!allowed) throw new Error("Free assessment limit reached");
+
+    const parts = [`Idea: ${args.concept}`];
+    if (args.audience) parts.push(`Target audience: ${args.audience}`);
+    if (args.timeline) parts.push(`Timeline: ${args.timeline}`);
+    const userMessage = parts.join("\n");
+
+    const client = getAnthropicClient();
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 4096,
+      system: ASSESS_SYSTEM_PROMPT,
+      tools: [{ type: "web_search_20250305" as const, name: "web_search", max_uses: 5 }],
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    // Find the last text block (after web search tool use)
+    const textBlocks = response.content.filter((b: { type: string }) => b.type === "text");
+    const lastText = textBlocks[textBlocks.length - 1];
+    const text = lastText && "text" in lastText ? (lastText as { text: string }).text : "";
+
+    const json = extractJSON(text);
+
+    // Increment usage after successful assessment
+    await ctx.runMutation(api.usage.increment);
+
+    return JSON.parse(json);
+  },
+});
+
+// ---------- refine ----------
+
+export const refine = action({
+  args: {
+    concept: v.string(),
+    audience: v.optional(v.string()),
+    verdict: v.string(),
+    demandScore: v.number(),
+    demandSummary: v.string(),
+    competitionScore: v.number(),
+    competitionSummary: v.string(),
+    shippabilityScore: v.number(),
+    shippabilitySummary: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const parts = [
+      `Idea: ${args.concept}`,
+      `Verdict: ${args.verdict}`,
+      `Demand: ${args.demandScore}/10 \u2014 ${args.demandSummary}`,
+      `Competition: ${args.competitionScore}/10 \u2014 ${args.competitionSummary}`,
+      `Shippability: ${args.shippabilityScore}/10 \u2014 ${args.shippabilitySummary}`,
+    ];
+    if (args.audience) parts.push(`Target audience: ${args.audience}`);
+
+    const client = getAnthropicClient();
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 2048,
+      system: REFINE_SYSTEM_PROMPT,
+      messages: [{ role: "user", content: parts.join("\n") }],
+    });
+
+    const textBlock = response.content.find((b: { type: string }) => b.type === "text");
+    const text = textBlock && "text" in textBlock ? (textBlock as { text: string }).text : "";
+
+    const json = extractJSON(text);
+    const parsed = JSON.parse(json);
+    // Mark all features as accepted by default
+    parsed.features = parsed.features.map((f: Record<string, unknown>) => ({ ...f, accepted: true }));
+
+    return parsed;
+  },
+});
+
+// ---------- buildPrompt ----------
+
+export const buildPrompt = action({
+  args: {
+    concept: v.string(),
+    audience: v.optional(v.string()),
+    personaName: v.string(),
+    personaDescription: v.string(),
+    personaPainPoints: v.array(v.string()),
+    features: v.array(v.object({
+      name: v.string(),
+      description: v.string(),
+      priority: v.string(),
+    })),
+    demandScore: v.number(),
+    competitionScore: v.number(),
+    shippabilityScore: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const featureList = args.features
+      .map((f) => `- ${f.name}: ${f.description}${f.priority === "must-have" ? " [MUST-HAVE]" : " [NICE-TO-HAVE]"}`)
+      .join("\n");
+
+    const userMessage = [
+      `Idea: ${args.concept}`,
+      args.audience ? `Audience: ${args.audience}` : null,
+      `\nTarget Persona: ${args.personaName}`,
+      args.personaDescription,
+      `Pain points: ${args.personaPainPoints.join("; ")}`,
+      `\nAccepted Features:\n${featureList}`,
+      `\nAssessment: Demand ${args.demandScore}/10, Competition ${args.competitionScore}/10, Shippability ${args.shippabilityScore}/10`,
+    ].filter(Boolean).join("\n");
+
+    const client = getAnthropicClient();
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 2048,
+      system: BUILD_PROMPT_SYSTEM,
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    const textBlock = response.content.find((b: { type: string }) => b.type === "text");
+    const text = textBlock && "text" in textBlock ? (textBlock as { text: string }).text : "";
+
+    return JSON.parse(extractJSON(text));
+  },
+});
+
+// ---------- generateTitle ----------
+
+export const generateTitle = action({
+  args: { concept: v.string() },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const client = getAnthropicClient();
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 30,
+      messages: [{
+        role: "user",
+        content: `Summarize this product idea into exactly 3-5 words as a short catchy title. No quotes, no punctuation, no explanation \u2014 just the title.\n\nIdea: ${args.concept}`,
+      }],
+    });
+
+    const block = response.content.find((b: { type: string }) => b.type === "text");
+    return block && "text" in block ? (block as { text: string }).text.trim() : args.concept.split(/\s+/).slice(0, 5).join(" ");
+  },
+});
+
+// ---------- generateConcept (Explore flow) ----------
+
+export const generateConcept = action({
+  args: {
+    branch: v.string(),
+    role: v.string(),
+    method: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getAuthUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+
+    const userInput = `Branch: ${args.branch}\nRole/interest: ${args.role}\nCurrent method: ${args.method}`;
+
+    const client = getGroqClient();
+    const response = await client.chat.completions.create({
+      model: "llama-3.3-70b-versatile",
+      max_tokens: 100,
+      response_format: { type: "json_object" },
+      messages: [
+        { role: "system", content: CONCEPT_PROMPT },
+        { role: "user", content: userInput },
+      ],
+    });
+
+    const text = response.choices[0]?.message?.content ?? "";
+    const parsed = JSON.parse(text) as { concept: string };
+    return parsed;
+  },
+});

--- a/convex/prompts.ts
+++ b/convex/prompts.ts
@@ -1,0 +1,160 @@
+// System prompts for AI actions — copied from src/lib/prompts.ts
+// These live in convex/ so they're available to server-side actions.
+
+export const CONCEPT_PROMPT = `You turn three pieces of information into one plain English product concept sentence. Be specific. No jargon.
+
+Input:
+- Branch: job or hobby
+- Role/interest: what they do
+- Current method: how they handle it today
+
+Output — return only valid JSON:
+{"concept":"one sentence describing the product idea"}
+
+Examples:
+- branch: job, role: healthcare, method: spreadsheet
+  \u2192 "A scheduling tool for healthcare teams that replaces the spreadsheet they're currently using to manage shifts"
+- branch: hobby, role: sport/fitness, method: just in my head
+  \u2192 "A personal training tracker for amateur athletes who currently just try to remember their progress"
+
+Keep it under 20 words. Plain English only. No "platform", no "solution", no "leverage".`;
+
+export const ASSESS_SYSTEM_PROMPT = `You are Launchable's idea assessor. You have access to web search. Your job is to research the idea using real web data, then score it honestly.
+
+PROCESS:
+1. Search the web for DEMAND signals: forums, Reddit threads, keyword interest, people actively looking for this
+2. Search the web for COMPETITION: existing products, tools, services that solve this problem, their funding and traction
+3. Score each dimension using the evidence you found
+4. Generate your assessment
+
+After completing your research, respond with ONLY valid JSON (no markdown fences, no extra text) matching this exact structure:
+
+{
+  "demand": {
+    "score": 1-10,
+    "summary": "2-3 sentences on market demand, grounded in what you found",
+    "evidence": [
+      {"text": "specific finding from your search", "source": "url"},
+      {"text": "another finding", "source": "url"}
+    ]
+  },
+  "competition": {
+    "score": 1-10,
+    "summary": "2-3 sentences on competitive landscape, citing actual competitors found",
+    "evidence": [
+      {"text": "specific competitor or market data", "source": "url"},
+      {"text": "another finding", "source": "url"}
+    ]
+  },
+  "shippability": {
+    "score": 1-10,
+    "summary": "2-3 sentences on build feasibility with AI coding tools",
+    "evidence": [
+      {"text": "reasoning about technical complexity"},
+      {"text": "what makes it easier or harder to ship"}
+    ]
+  },
+  "verdict": "2-3 plain-language sentences. Be honest and direct.",
+  "ai_wrapper_flag": true/false,
+  "ai_wrapper_explanation": "One sentence explaining why this is or isn't an AI wrapper. Only include if ai_wrapper_flag is true.",
+  "mutations": [
+    {"type": "pivot", "idea": "A different angle on the same problem", "score_indication": "e.g. better demand, less competition"},
+    {"type": "niche", "idea": "A narrower, more winnable version", "score_indication": "e.g. lower competition, strong niche demand"},
+    {"type": "expand", "idea": "A more ambitious version", "score_indication": "e.g. higher demand, harder to ship"}
+  ],
+  "build_tool": "claude-code"|"lovable"|"bolt"|"replit",
+  "build_prompt": "A detailed, ready-to-paste prompt for the recommended tool. Include what the app does, core features (bulleted), tech stack, page/screen breakdown, and key UX details."
+}
+
+IMPORTANT RULES:
+- You MUST search the web before scoring. Do not skip research.
+- Each evidence array must have 2-3 items from your web research
+- Demand and competition scores MUST be grounded in search evidence, not intuition
+- Shippability is your own technical judgment \u2014 no search needed
+- If search results are thin or inconclusive, say so honestly and score conservatively
+
+Score meanings:
+- demand: How many people have this problem? (10 = massive market, clear search signal)
+- competition: How crowded is the space? (10 = very competitive, many established players found)
+- shippability: How feasible to build with an AI coding tool in a weekend? (10 = very shippable)
+
+Tool selection guide:
+- claude-code: Complex apps, APIs, full-stack, anything needing backend logic
+- lovable: Beautiful landing pages, simple SaaS, visual-first apps
+- bolt: Quick prototypes, simple web tools, single-page apps
+- replit: Learning projects, experiments, multiplayer/collaborative tools
+
+AI wrapper flag: Set to true if the idea is essentially a thin UI layer over an LLM API with no unique data, workflow, or defensible moat.
+
+Be honest. A mediocre idea scored high is worse than a good idea scored fairly.`;
+
+export const REFINE_SYSTEM_PROMPT = `You are Launchable's idea refinement engine. Given a product idea and its assessment scores, generate a target persona and a prioritized feature set.
+
+Respond with ONLY valid JSON (no markdown fences, no extra text):
+
+{
+  "persona": {
+    "name": "A short persona label, e.g. 'Freelance Designer'",
+    "description": "2-3 sentences describing who this person is, their context, and why they need this product",
+    "pain_points": ["specific pain point 1", "specific pain point 2", "specific pain point 3"]
+  },
+  "features": [
+    {
+      "id": "f1",
+      "name": "Short feature name",
+      "description": "One sentence explaining what this feature does and why it matters",
+      "priority": "must-have",
+      "complexity": "low",
+      "user_appetite": "One sentence explaining why users want this \u2014 what frustration does it solve or what delight does it create?"
+    },
+    {
+      "id": "f2",
+      "name": "Another feature",
+      "description": "One sentence explaining what this feature does",
+      "priority": "nice-to-have",
+      "complexity": "high",
+      "user_appetite": "One sentence on user demand signal"
+    }
+  ]
+}
+
+RULES:
+- Generate 5-8 features total
+- 3-4 should be "must-have" (core functionality needed for MVP)
+- 2-4 should be "nice-to-have" (valuable but can ship without)
+- Features should be specific and actionable, not vague ("Email digest of weekly stats" not "Analytics")
+- The persona should feel like a real person, not a marketing segment
+- Pain points should be specific frustrations, not generic problems
+- If the user provided a target audience, use that to inform the persona
+- Order features by priority (must-haves first)
+
+COMPLEXITY levels:
+- "low": Can be built in under an hour with an AI coding tool. Simple CRUD, static UI, basic forms
+- "medium": A few hours of work. Requires some integration, state management, or non-trivial logic
+- "high": Significant effort. Needs external APIs, complex algorithms, real-time features, or auth flows
+
+USER APPETITE:
+- For each feature, explain WHY users want it \u2014 reference the persona's pain points
+- Be specific: "Freelancers forget to follow up on invoices, costing them an average of 15% in lost revenue" not "Users want reminders"
+- This helps the user decide whether the feature is worth the complexity cost`;
+
+export const BUILD_PROMPT_SYSTEM = `You are Launchable's build prompt generator. Given an idea, a target persona, and a curated feature list, generate a detailed, ready-to-paste prompt for an AI coding tool.
+
+Respond with ONLY valid JSON (no markdown fences, no extra text):
+
+{"tool":"claude-code"|"lovable"|"bolt"|"replit","reasoning":"1-2 sentences on why this tool is the best fit","prompt":"The full build prompt, ready to paste into the AI coding tool."}
+
+The prompt MUST include:
+- What the app does (1-2 sentences, referencing the persona)
+- Core features \u2014 ONLY the features the user accepted, bulleted
+- Tech stack recommendation appropriate for the tool
+- Page/screen breakdown derived from the features
+- Key UX details tailored to the persona
+
+Tool selection guide:
+- claude-code: Complex apps, APIs, full-stack, anything needing backend logic
+- lovable: Beautiful landing pages, simple SaaS, visual-first apps
+- bolt: Quick prototypes, simple web tools, single-page apps
+- replit: Learning projects, experiments, multiplayer/collaborative tools
+
+IMPORTANT: Only include features that were explicitly provided. Do not add features the user didn't select.`;

--- a/src/hooks/useAssessIdea.ts
+++ b/src/hooks/useAssessIdea.ts
@@ -1,7 +1,6 @@
 import { useState, useCallback } from 'react';
-import { useMutation } from 'convex/react';
+import { useAction, useMutation } from 'convex/react';
 import { api } from '../../convex/_generated/api';
-import { getAnthropicClient } from '../lib/claude';
 import { ASSESS_SYSTEM_PROMPT } from '../lib/prompts';
 import { IS_MOCK, mockAssess } from '../lib/mock';
 import { IS_LOCAL_LLM, localAssess } from '../lib/local-llm';
@@ -12,16 +11,12 @@ export function useAssessIdea() {
   const [assessment, setAssessment] = useState<Assessment | null>(null);
   const [error, setError] = useState<string | null>(null);
   const incrementUsage = useMutation(api.usage.increment);
+  const assessAction = useAction(api.ai.assess);
 
   const assess = useCallback(async (input: IdeaInput) => {
     setIsLoading(true);
     setError(null);
     setAssessment(null);
-
-    const parts = [`Idea: ${input.concept}`];
-    if (input.audience) parts.push(`Target audience: ${input.audience}`);
-    if (input.timeline) parts.push(`Timeline: ${input.timeline}`);
-    const userMessage = parts.join('\n');
 
     try {
       if (IS_MOCK) {
@@ -31,35 +26,30 @@ export function useAssessIdea() {
         return;
       }
 
-      let text: string;
-
       if (IS_LOCAL_LLM) {
-        text = await localAssess(userMessage, ASSESS_SYSTEM_PROMPT);
-      } else {
-        const client = getAnthropicClient();
-        const response = await client.messages.create({
-          model: 'claude-sonnet-4-20250514',
-          max_tokens: 4096,
-          system: ASSESS_SYSTEM_PROMPT,
-          tools: [{ type: 'web_search_20250305', name: 'web_search', max_uses: 5 }],
-          messages: [{ role: 'user', content: userMessage }],
-        });
+        const parts = [`Idea: ${input.concept}`];
+        if (input.audience) parts.push(`Target audience: ${input.audience}`);
+        if (input.timeline) parts.push(`Timeline: ${input.timeline}`);
+        const userMessage = parts.join('\n');
 
-        // Find the last text block (after web search tool use)
-        const textBlocks = response.content.filter((b) => b.type === 'text');
-        const lastText = textBlocks[textBlocks.length - 1];
-        text = lastText && 'text' in lastText ? lastText.text : '';
+        const text = await localAssess(userMessage, ASSESS_SYSTEM_PROMPT);
+        const jsonMatch = text.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) throw new Error('No valid JSON found in response');
+
+        const parsed = JSON.parse(jsonMatch[0]) as Assessment;
+        setAssessment(parsed);
+        void incrementUsage();
+        return;
       }
 
-      // Extract JSON from the response (may be wrapped in markdown fences)
-      const jsonMatch = text.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) {
-        throw new Error('No valid JSON found in response');
-      }
-
-      const parsed = JSON.parse(jsonMatch[0]) as Assessment;
+      // Production: use server-side Convex action
+      const parsed = await assessAction({
+        concept: input.concept,
+        audience: input.audience,
+        timeline: input.timeline,
+      }) as Assessment;
       setAssessment(parsed);
-      void incrementUsage();
+      // Usage is incremented server-side by the action
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Something went wrong',
@@ -67,7 +57,7 @@ export function useAssessIdea() {
     } finally {
       setIsLoading(false);
     }
-  }, [incrementUsage]);
+  }, [incrementUsage, assessAction]);
 
   return { isLoading, assessment, error, assess };
 }

--- a/src/hooks/useRefineIdea.ts
+++ b/src/hooks/useRefineIdea.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
-import { getAnthropicClient } from '../lib/claude';
+import { useAction } from 'convex/react';
+import { api } from '../../convex/_generated/api';
 import { REFINE_SYSTEM_PROMPT } from '../lib/prompts';
 import { IS_MOCK, mockRefine } from '../lib/mock';
 import { IS_LOCAL_LLM, localRefine } from '../lib/local-llm';
@@ -9,19 +10,11 @@ export function useRefineIdea() {
   const [isLoading, setIsLoading] = useState(false);
   const [refinement, setRefinement] = useState<Refinement | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const refineAction = useAction(api.ai.refine);
 
   const refine = useCallback(async (concept: string, audience: string | undefined, assessment: Assessment) => {
     setIsLoading(true);
     setError(null);
-
-    const parts = [
-      `Idea: ${concept}`,
-      `Verdict: ${assessment.verdict}`,
-      `Demand: ${assessment.demand.score}/10 — ${assessment.demand.summary}`,
-      `Competition: ${assessment.competition.score}/10 — ${assessment.competition.summary}`,
-      `Shippability: ${assessment.shippability.score}/10 — ${assessment.shippability.summary}`,
-    ];
-    if (audience) parts.push(`Target audience: ${audience}`);
 
     try {
       if (IS_MOCK) {
@@ -30,36 +23,45 @@ export function useRefineIdea() {
         return;
       }
 
-      let text: string;
-
       if (IS_LOCAL_LLM) {
-        text = await localRefine(parts.join('\n'), REFINE_SYSTEM_PROMPT);
-      } else {
-        const client = getAnthropicClient();
-        const response = await client.messages.create({
-          model: 'claude-sonnet-4-20250514',
-          max_tokens: 2048,
-          system: REFINE_SYSTEM_PROMPT,
-          messages: [{ role: 'user', content: parts.join('\n') }],
-        });
+        const parts = [
+          `Idea: ${concept}`,
+          `Verdict: ${assessment.verdict}`,
+          `Demand: ${assessment.demand.score}/10 — ${assessment.demand.summary}`,
+          `Competition: ${assessment.competition.score}/10 — ${assessment.competition.summary}`,
+          `Shippability: ${assessment.shippability.score}/10 — ${assessment.shippability.summary}`,
+        ];
+        if (audience) parts.push(`Target audience: ${audience}`);
 
-        const textBlock = response.content.find((b) => b.type === 'text');
-        text = textBlock && 'text' in textBlock ? textBlock.text : '';
+        const text = await localRefine(parts.join('\n'), REFINE_SYSTEM_PROMPT);
+        const jsonMatch = text.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) throw new Error('No valid JSON found in response');
+
+        const parsed = JSON.parse(jsonMatch[0]) as Refinement;
+        parsed.features = parsed.features.map((f) => ({ ...f, accepted: true }));
+        setRefinement(parsed);
+        return;
       }
 
-      const jsonMatch = text.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) throw new Error('No valid JSON found in response');
-
-      const parsed = JSON.parse(jsonMatch[0]) as Refinement;
-      // Mark all features as accepted by default
-      parsed.features = parsed.features.map((f) => ({ ...f, accepted: true }));
+      // Production: use server-side Convex action
+      const parsed = await refineAction({
+        concept,
+        audience,
+        verdict: assessment.verdict,
+        demandScore: assessment.demand.score,
+        demandSummary: assessment.demand.summary,
+        competitionScore: assessment.competition.score,
+        competitionSummary: assessment.competition.summary,
+        shippabilityScore: assessment.shippability.score,
+        shippabilitySummary: assessment.shippability.summary,
+      }) as Refinement;
       setRefinement(parsed);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong');
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [refineAction]);
 
   return { isLoading, refinement, setRefinement, error, refine };
 }

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, ArrowRight, Loader2, SendHorizonal, Rocket } from 'lucide-react';
-import { getClient } from '../lib/groq';
+import { useAction } from 'convex/react';
+import { api } from '../../convex/_generated/api';
 import { CONCEPT_PROMPT } from '../lib/prompts';
 import { IS_LOCAL_LLM, localGenerateConcept } from '../lib/local-llm';
 
@@ -62,6 +63,7 @@ type Branch = 'job' | 'hobby' | null;
 
 export default function ExplorePage() {
   const navigate = useNavigate();
+  const generateConceptAction = useAction(api.ai.generateConcept);
   const [phase, setPhase] = useState<'interstitial' | 'tree'>('interstitial');
 
   const [step, setStep] = useState<Step>(1);
@@ -146,26 +148,20 @@ export default function ExplorePage() {
     setConceptLoading(true);
     setError(null);
     try {
-      const userInput = `Branch: ${branch}\nRole/interest: ${role}\nCurrent method: ${answer}`;
-      let text: string;
+      let parsed: { concept: string };
 
       if (IS_LOCAL_LLM) {
-        text = await localGenerateConcept(userInput, CONCEPT_PROMPT);
+        const userInput = `Branch: ${branch}\nRole/interest: ${role}\nCurrent method: ${answer}`;
+        const text = await localGenerateConcept(userInput, CONCEPT_PROMPT);
+        parsed = JSON.parse(text) as { concept: string };
       } else {
-        const client = getClient();
-        const response = await client.chat.completions.create({
-          model: 'llama-3.3-70b-versatile',
-          max_tokens: 100,
-          response_format: { type: 'json_object' },
-          messages: [
-            { role: 'system', content: CONCEPT_PROMPT },
-            { role: 'user', content: userInput },
-          ],
+        // Production: use server-side Convex action
+        parsed = await generateConceptAction({
+          branch: branch!,
+          role: role!,
+          method: answer,
         });
-        text = response.choices[0]?.message?.content ?? '';
       }
-
-      const parsed = JSON.parse(text) as { concept: string };
 
       await new Promise((r) => setTimeout(r, 600));
 

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -10,9 +10,8 @@ import {
   Star,
   Bookmark,
 } from 'lucide-react';
-import { getAnthropicClient } from '../lib/claude';
 import { BUILD_PROMPT_SYSTEM } from '../lib/prompts';
-import { useMutation } from 'convex/react';
+import { useMutation, useAction } from 'convex/react';
 import { api } from '../../convex/_generated/api';
 import { BUILD_TOOLS } from '../lib/constants';
 import { IS_MOCK, mockBuildPrompt, mockGenerateTitle } from '../lib/mock';
@@ -41,6 +40,8 @@ export default function ResultPage() {
   const navigate = useNavigate();
   const state = location.state as RefinedResultState | LegacyResultState | null;
   const saveIdea = useMutation(api.ideas.save);
+  const buildPromptAction = useAction(api.ai.buildPrompt);
+  const generateTitleAction = useAction(api.ai.generateTitle);
 
   const [buildPrompt, setBuildPrompt] = useState<BuildPrompt | null>(null);
   const [loading, setLoading] = useState(false);
@@ -87,41 +88,44 @@ export default function ResultPage() {
         return;
       }
 
-      const featureList = s.features
-        .map((f) => `- ${f.name}: ${f.description}${f.priority === 'must-have' ? ' [MUST-HAVE]' : ' [NICE-TO-HAVE]'}`)
-        .join('\n');
-
-      const userMessage = [
-        `Idea: ${s.concept}`,
-        s.audience ? `Audience: ${s.audience}` : null,
-        `\nTarget Persona: ${s.persona.name}`,
-        s.persona.description,
-        `Pain points: ${s.persona.pain_points.join('; ')}`,
-        `\nAccepted Features:\n${featureList}`,
-        `\nAssessment: Demand ${s.assessment.demand.score}/10, Competition ${s.assessment.competition.score}/10, Shippability ${s.assessment.shippability.score}/10`,
-      ].filter(Boolean).join('\n');
-
-      let text: string;
-
       if (IS_LOCAL_LLM) {
-        text = await localBuildPrompt(userMessage, BUILD_PROMPT_SYSTEM);
-      } else {
-        const client = getAnthropicClient();
-        const response = await client.messages.create({
-          model: 'claude-haiku-4-5-20251001',
-          max_tokens: 2048,
-          system: BUILD_PROMPT_SYSTEM,
-          messages: [{ role: 'user', content: userMessage }],
-        });
+        const featureList = s.features
+          .map((f) => `- ${f.name}: ${f.description}${f.priority === 'must-have' ? ' [MUST-HAVE]' : ' [NICE-TO-HAVE]'}`)
+          .join('\n');
 
-        const textBlock = response.content.find((b) => b.type === 'text');
-        text = textBlock && 'text' in textBlock ? textBlock.text : '';
+        const userMessage = [
+          `Idea: ${s.concept}`,
+          s.audience ? `Audience: ${s.audience}` : null,
+          `\nTarget Persona: ${s.persona.name}`,
+          s.persona.description,
+          `Pain points: ${s.persona.pain_points.join('; ')}`,
+          `\nAccepted Features:\n${featureList}`,
+          `\nAssessment: Demand ${s.assessment.demand.score}/10, Competition ${s.assessment.competition.score}/10, Shippability ${s.assessment.shippability.score}/10`,
+        ].filter(Boolean).join('\n');
+
+        const text = await localBuildPrompt(userMessage, BUILD_PROMPT_SYSTEM);
+        const jsonMatch = text.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) throw new Error('No valid JSON in response');
+        setBuildPrompt(JSON.parse(jsonMatch[0]) as BuildPrompt);
+        return;
       }
 
-      const jsonMatch = text.match(/\{[\s\S]*\}/);
-      if (!jsonMatch) throw new Error('No valid JSON in response');
-
-      const parsed = JSON.parse(jsonMatch[0]) as BuildPrompt;
+      // Production: use server-side Convex action
+      const parsed = await buildPromptAction({
+        concept: s.concept,
+        audience: s.audience,
+        personaName: s.persona.name,
+        personaDescription: s.persona.description,
+        personaPainPoints: s.persona.pain_points,
+        features: s.features.map((f) => ({
+          name: f.name,
+          description: f.description,
+          priority: f.priority,
+        })),
+        demandScore: s.assessment.demand.score,
+        competitionScore: s.assessment.competition.score,
+        shippabilityScore: s.assessment.shippability.score,
+      }) as BuildPrompt;
       setBuildPrompt(parsed);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong');
@@ -156,17 +160,7 @@ export default function ResultPage() {
       }
     }
     try {
-      const client = getAnthropicClient();
-      const response = await client.messages.create({
-        model: 'claude-haiku-4-5-20251001',
-        max_tokens: 30,
-        messages: [{
-          role: 'user',
-          content: `Summarize this product idea into exactly 3-5 words as a short catchy title. No quotes, no punctuation, no explanation — just the title.\n\nIdea: ${concept}`,
-        }],
-      });
-      const block = response.content.find((b) => b.type === 'text');
-      return block && 'text' in block ? block.text.trim() : concept.split(/\s+/).slice(0, 5).join(' ');
+      return await generateTitleAction({ concept });
     } catch {
       return concept.split(/\s+/).slice(0, 5).join(' ');
     }


### PR DESCRIPTION
## Summary
- Create `convex/ai.ts` with 5 server-side actions: `assess`, `refine`, `buildPrompt`, `generateTitle`, `generateConcept`
- Create `convex/prompts.ts` with system prompts (copied from `src/lib/prompts.ts`)
- Wire frontend hooks (`useAssessIdea`, `useRefineIdea`) and pages (`ResultPage`, `ExplorePage`) to call Convex actions in production mode
- Remove browser-side Anthropic/Groq SDK usage from production code paths
- Usage limit enforced server-side in `assess` action via `checkLimit` query
- `VITE_LOCAL_LLM` and `VITE_MOCK_API` dev modes preserved

## Security improvement
API keys (`ANTHROPIC_API_KEY`, `GROQ_API_KEY`) now live only as Convex environment variables — never in the browser bundle.

## Environment setup required
```bash
npx convex env set ANTHROPIC_API_KEY <key>
npx convex env set GROQ_API_KEY <key>
```

## Test plan
- [x] `npm run build` passes with zero TS errors
- [x] `npx convex dev --once` deploys successfully
- [ ] Assessment flow works via Convex action (with web search)
- [ ] Refine flow works via Convex action
- [ ] Build prompt generation works via Convex action
- [ ] Explore concept generation works via Convex action
- [ ] `VITE_LOCAL_LLM=true` still works for local dev
- [ ] `VITE_MOCK_API=true` still works for testing

Closes #25, Closes #26, Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)